### PR TITLE
Add Android skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
+# PGPAndy
 
+Placeholder Android app with navigation drawer, forms for storing PGP contacts, a message creator, and theme toggle.
+
+## Building
+
+This project uses Gradle and requires the Android SDK. Run:
+
+```bash
+./gradlew assembleDebug
+```
+
+## Tests
+
+No tests are provided.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,51 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.pgpandy'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.pgpandy"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.4'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+    implementation platform('androidx.compose:compose-bom:2024.03.00')
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.activity:activity-compose:1.9.0'
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# ProGuard rules placeholder

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<manifest package="com.example.pgpandy" xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="true"
+        android:theme="@style/Theme.PGPAndy">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/pgpandy/MainActivity.kt
+++ b/app/src/main/java/com/example/pgpandy/MainActivity.kt
@@ -1,0 +1,111 @@
+package com.example.pgpandy
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
+import androidx.compose.ui.Alignment
+import kotlinx.coroutines.launch
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContent { PGPAndyApp() }
+    }
+}
+
+@Composable
+fun PGPAndyApp() {
+    var darkTheme by remember { mutableStateOf(false) }
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    var screen by remember { mutableStateOf(Screen.Contacts) }
+
+    MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            drawerContent = {
+                ModalDrawerSheet {
+                    Text("PGPAndy", modifier = Modifier.padding(16.dp), style = MaterialTheme.typography.titleMedium)
+                    NavigationDrawerItem(
+                        label = { Text("Contacts") },
+                        selected = screen == Screen.Contacts,
+                        onClick = { screen = Screen.Contacts; scope.launch { drawerState.close() } }
+                    )
+                    NavigationDrawerItem(
+                        label = { Text("Create Message") },
+                        selected = screen == Screen.Message,
+                        onClick = { screen = Screen.Message; scope.launch { drawerState.close() } }
+                    )
+                }
+            }
+        ) {
+            Scaffold(
+                topBar = {
+                    SmallTopAppBar(
+                        title = { Text("PGPAndy") },
+                        navigationIcon = {
+                            IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                                Icon(Icons.Default.Menu, contentDescription = "Menu")
+                            }
+                        },
+                        actions = {
+                            IconButton(onClick = { /* search */ }) {
+                                Icon(Icons.Default.Search, contentDescription = "Search")
+                            }
+                            IconButton(onClick = { /* lock */ }) {
+                                Icon(Icons.Default.Lock, contentDescription = "Lock")
+                            }
+                            IconButton(onClick = { darkTheme = !darkTheme }) {
+                                Icon(
+                                    if (darkTheme) Icons.Default.LightMode else Icons.Default.DarkMode,
+                                    contentDescription = "Theme"
+                                )
+                            }
+                        }
+                    )
+                }
+            ) { padding ->
+                Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+                    when (screen) {
+                        Screen.Contacts -> ContactForm()
+                        Screen.Message -> MessageForm()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum class Screen { Contacts, Message }
+
+@Composable
+fun ContactForm() {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text("PGP Contact", style = MaterialTheme.typography.titleMedium)
+        OutlinedTextField(value = "", onValueChange = {}, label = { Text("Name") }, modifier = Modifier.fillMaxWidth())
+        OutlinedTextField(value = "", onValueChange = {}, label = { Text("Public Key") }, modifier = Modifier.fillMaxWidth())
+        Button(onClick = { /* save */ }, modifier = Modifier.align(Alignment.End)) { Text("Save") }
+    }
+}
+
+@Composable
+fun MessageForm() {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Create Message", style = MaterialTheme.typography.titleMedium)
+        OutlinedTextField(value = "", onValueChange = {}, label = { Text("Recipient") }, modifier = Modifier.fillMaxWidth())
+        OutlinedTextField(value = "", onValueChange = {}, label = { Text("Message") }, modifier = Modifier.fillMaxWidth())
+        Button(onClick = { /* send */ }, modifier = Modifier.align(Alignment.End)) { Text("Send") }
+    }
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.PGPAndy" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'com.android.application' version '8.2.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx1536m
+android.useAndroidX=true
+kotlin.code.style=official

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "PGPAndy"
+include(":app")


### PR DESCRIPTION
## Summary
- initialize gradle-based Android project
- add navigation drawer example with Compose
- include placeholder forms for contacts and messages
- document how to build

## Testing
- `gradle assembleDebug` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856db55806c832d8f647a9aa0026b3f