### PR TITLE
Initialize SQLite database on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ This project uses Gradle 8.5 with Android Gradle Plugin 8.4.1 and requires the A
 ## Tests
 
 No tests are provided.
+
+## Database setup
+
+The app initializes its SQLite database automatically when first launched. The
+database contains `preferences` and `keys` tables for storing settings and PGP
+key information. No manual setup is required.

--- a/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
@@ -1,0 +1,46 @@
+package com.example.pgpandy
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+
+private const val DB_NAME = "pgpandy.db"
+private const val DB_VERSION = 1
+
+class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DB_NAME, null, DB_VERSION) {
+
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS preferences (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                value TEXT
+            )
+            """.trimIndent()
+        )
+
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS keys (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_name TEXT NOT NULL,
+                owner_email TEXT,
+                public_key TEXT NOT NULL,
+                private_key TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """.trimIndent()
+        )
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        // Future database migrations can be handled here. The simple example
+        // just recreates the schema if a version change is detected.
+        if (oldVersion != newVersion) {
+            db.execSQL("DROP TABLE IF EXISTS preferences")
+            db.execSQL("DROP TABLE IF EXISTS keys")
+            onCreate(db)
+        }
+    }
+}

--- a/app/src/main/java/com/example/pgpandy/MainActivity.kt
+++ b/app/src/main/java/com/example/pgpandy/MainActivity.kt
@@ -30,6 +30,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Initialize local database on first launch. This will create tables
+        // or run migrations as needed based on the defined DB version.
+        DatabaseHelper(this).writableDatabase
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent { PGPAndyApp() }
     }


### PR DESCRIPTION
## Summary
- automatically create the local SQLite database using `DatabaseHelper`
- invoke database initialization from `MainActivity`
- remove the obsolete install script and update documentation

## Testing
- `./gradlew tasks --all`


------
https://chatgpt.com/codex/tasks/task_e_68574fef1d94832d9c6d608a9f83cb04