### PR TITLE
Persist dark mode preference

### DIFF
--- a/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
@@ -3,6 +3,7 @@ package com.example.pgpandy
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
+import android.content.ContentValues
 
 private const val DB_NAME = "pgpandy.db"
 private const val DB_VERSION = 1
@@ -63,5 +64,27 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DB_NAME, null
         if (oldVersion != newVersion) {
 
         }
+    }
+
+    fun getPreference(name: String): String? {
+        readableDatabase.rawQuery(
+            "SELECT value FROM preferences WHERE name = ?",
+            arrayOf(name)
+        ).use { cursor ->
+            return if (cursor.moveToFirst()) cursor.getString(0) else null
+        }
+    }
+
+    fun setPreference(name: String, value: String) {
+        val values = ContentValues().apply {
+            put("name", name)
+            put("value", value)
+        }
+        writableDatabase.insertWithOnConflict(
+            "preferences",
+            null,
+            values,
+            SQLiteDatabase.CONFLICT_REPLACE
+        )
     }
 }

--- a/app/src/main/java/com/example/pgpandy/MainActivity.kt
+++ b/app/src/main/java/com/example/pgpandy/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Send
 import androidx.compose.ui.graphics.Color
 import androidx.core.os.LocaleListCompat
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.platform.LocalContext
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,6 +47,15 @@ fun PGPAndyApp() {
     val scope = rememberCoroutineScope()
     var screen by remember { mutableStateOf(Screen.ContactList) }
     var languageMenuExpanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        darkTheme = DatabaseHelper(context).getPreference("dark_theme") == "1"
+    }
+
+    LaunchedEffect(darkTheme) {
+        DatabaseHelper(context).setPreference("dark_theme", if (darkTheme) "1" else "0")
+    }
 
     MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
         ModalNavigationDrawer(


### PR DESCRIPTION
## Summary
- store/retrieve preferences in `DatabaseHelper`
- remember the user's dark theme choice in the database

## Testing
- `gradle` build *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_685755c0cc14832dae6f53dae144b10c