### PR TITLE
Refactor screens into composables

### DIFF
--- a/app/src/main/java/com/example/pgpandy/ContactForm.kt
+++ b/app/src/main/java/com/example/pgpandy/ContactForm.kt
@@ -1,0 +1,46 @@
+package com.example.pgpandy
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ContactForm(onSaved: () -> Unit) {
+    var name by remember { mutableStateOf("") }
+    var key by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(stringResource(R.string.title_pgp_contact))
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text(stringResource(R.string.label_name)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = key,
+            onValueChange = { key = it },
+            label = { Text(stringResource(R.string.label_public_key)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Button(
+            onClick = {
+                ContactRepository.contacts.add(Contact(name, key))
+                onSaved()
+            },
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Text(stringResource(R.string.action_save))
+        }
+    }
+}

--- a/app/src/main/java/com/example/pgpandy/ContactListScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/ContactListScreen.kt
@@ -1,0 +1,58 @@
+package com.example.pgpandy
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material3.Divider
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ContactListScreen(onAddContact: () -> Unit) {
+    val contacts = ContactRepository.contacts
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (contacts.isEmpty()) {
+            Text(stringResource(R.string.msg_no_contacts), modifier = Modifier.align(Alignment.Center))
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(contacts) { contact ->
+                    ListItem(
+                        headlineContent = { Text(contact.name) },
+                        supportingContent = { Text(contact.publicKey) }
+                    )
+                    Divider()
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = onAddContact,
+            modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+            containerColor = Color(0xFF440020),
+            contentColor = Color.White
+        ) {
+            Icon(Icons.Default.PersonAdd, contentDescription = stringResource(R.string.cd_add_contact))
+        }
+    }
+}
+
+// Simple data structures kept here for now
+data class Contact(val name: String, val publicKey: String)
+
+object ContactRepository {
+    val contacts = mutableStateListOf<Contact>()
+}

--- a/app/src/main/java/com/example/pgpandy/HelpScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/HelpScreen.kt
@@ -1,0 +1,15 @@
+package com.example.pgpandy
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HelpScreen() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Text("Help", modifier = Modifier.align(Alignment.Center))
+    }
+}

--- a/app/src/main/java/com/example/pgpandy/InboxScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/InboxScreen.kt
@@ -1,0 +1,15 @@
+package com.example.pgpandy
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun InboxScreen() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Text("Inbox", modifier = Modifier.align(Alignment.Center))
+    }
+}

--- a/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
@@ -1,0 +1,31 @@
+package com.example.pgpandy
+
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun KeyListScreen(onAddKey: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Text("No private keys added.", modifier = Modifier.align(Alignment.Center))
+
+        FloatingActionButton(
+            onClick = onAddKey,
+            modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+            containerColor = Color(0xFF440020),
+            contentColor = Color.White
+        ) {
+            Icon(Icons.Default.Key, contentDescription = null)
+        }
+    }
+}

--- a/app/src/main/java/com/example/pgpandy/MessageForm.kt
+++ b/app/src/main/java/com/example/pgpandy/MessageForm.kt
@@ -1,0 +1,51 @@
+package com.example.pgpandy
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MessageForm() {
+    var recipient by remember { mutableStateOf("") }
+    var message by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(stringResource(R.string.title_create_message))
+        OutlinedTextField(
+            value = recipient,
+            onValueChange = { recipient = it },
+            label = { Text(stringResource(R.string.label_recipient)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = message,
+            onValueChange = { message = it },
+            label = { Text(stringResource(R.string.label_message)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Button(
+            onClick = { /* send */ },
+            modifier = Modifier.align(Alignment.End),
+            shape = RoundedCornerShape(6.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFF440020),
+                contentColor = Color.White
+            )
+        ) {
+            Text(stringResource(R.string.action_send))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract `MessageForm`, `ContactListScreen`, `ContactForm`, and `KeyListScreen` into their own files
- add placeholder `InboxScreen` and `HelpScreen`
- update `PGPAndyApp` to reference these components
- support navigation drawer selection for Inbox and Help

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685779b5a36c832db14d9b821fad6076