### PR TITLE
Add PGP key generation dialog

### DIFF
--- a/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
@@ -1,0 +1,177 @@
+package com.example.pgpandy
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+
+/** Data container for the key generation form fields. */
+data class KeyFormData(
+    val label: String,
+    val name: String,
+    val email: String,
+    val algorithm: String,
+    val bitLength: Int,
+    val password: String,
+    val confirmPassword: String,
+    val notes: String
+)
+
+/** Dialog containing form fields for generating a new PGP key pair. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun KeyGenerationDialog(
+    onDismiss: () -> Unit,
+    onCreate: (KeyFormData) -> Unit = {}
+) {
+    var label by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var algorithm by remember { mutableStateOf("RSA") }
+    var algorithmExpanded by remember { mutableStateOf(false) }
+    var bitLength by remember { mutableStateOf(2048) }
+    var bitExpanded by remember { mutableStateOf(false) }
+    var password by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+
+    val algorithms = listOf("RSA", "DSA", "ECDSA", "EdDSA")
+    val bitOptions = listOf(2048, 3072, 4096)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                onCreate(
+                    KeyFormData(
+                        label,
+                        name,
+                        email,
+                        algorithm,
+                        bitLength,
+                        password,
+                        confirmPassword,
+                        notes
+                    )
+                )
+                onDismiss()
+            }) {
+                Text(stringResource(R.string.action_create))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_close))
+            }
+        },
+        title = { Text(stringResource(R.string.title_generate_key)) },
+        text = {
+            Column(modifier = Modifier.padding(top = 8.dp)) {
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    label = { Text(stringResource(R.string.label_key_label)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.label_name)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = { Text(stringResource(R.string.label_email)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                ExposedDropdownMenuBox(
+                    expanded = algorithmExpanded,
+                    onExpandedChange = { algorithmExpanded = !algorithmExpanded }
+                ) {
+                    OutlinedTextField(
+                        value = algorithm,
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text(stringResource(R.string.label_algorithm)) },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = algorithmExpanded)
+                        },
+                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = algorithmExpanded,
+                        onDismissRequest = { algorithmExpanded = false }
+                    ) {
+                        algorithms.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(option) },
+                                onClick = {
+                                    algorithm = option
+                                    algorithmExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                ExposedDropdownMenuBox(
+                    expanded = bitExpanded,
+                    onExpandedChange = { bitExpanded = !bitExpanded }
+                ) {
+                    OutlinedTextField(
+                        value = bitLength.toString(),
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text(stringResource(R.string.label_bit_length)) },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = bitExpanded)
+                        },
+                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = bitExpanded,
+                        onDismissRequest = { bitExpanded = false }
+                    ) {
+                        bitOptions.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(option.toString()) },
+                                onClick = {
+                                    bitLength = option
+                                    bitExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text(stringResource(R.string.label_password)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    visualTransformation = PasswordVisualTransformation()
+                )
+                OutlinedTextField(
+                    value = confirmPassword,
+                    onValueChange = { confirmPassword = it },
+                    label = { Text(stringResource(R.string.label_confirm_password)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    visualTransformation = PasswordVisualTransformation()
+                )
+                OutlinedTextField(
+                    value = notes,
+                    onValueChange = { notes = it },
+                    label = { Text(stringResource(R.string.label_notes)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
@@ -3,7 +3,7 @@ package com.example.pgpandy
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.Box
@@ -15,17 +15,23 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 
 @Composable
-fun KeyListScreen(onAddKey: () -> Unit) {
+fun KeyListScreen() {
+    var showDialog by remember { mutableStateOf(false) }
+
     Box(modifier = Modifier.fillMaxSize()) {
         Text("No private keys added.", modifier = Modifier.align(Alignment.Center))
 
         FloatingActionButton(
-            onClick = onAddKey,
+            onClick = { showDialog = true },
             modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
             containerColor = Color(0xFF440020),
             contentColor = Color.White
         ) {
             Icon(Icons.Default.Key, contentDescription = null)
+        }
+
+        if (showDialog) {
+            KeyGenerationDialog(onDismiss = { showDialog = false })
         }
     }
 }

--- a/app/src/main/java/com/example/pgpandy/MainActivity.kt
+++ b/app/src/main/java/com/example/pgpandy/MainActivity.kt
@@ -229,7 +229,7 @@ fun PGPAndyApp(initialLanguageTag: String) {
                         Screen.Inbox -> InboxScreen()
                         Screen.Message -> MessageForm()
                         Screen.ContactList -> ContactListScreen { screen = Screen.AddContact }
-                        Screen.KeyList -> KeyListScreen { screen = Screen.KeyList }
+                        Screen.KeyList -> KeyListScreen()
                         Screen.AddContact -> ContactForm { screen = Screen.ContactList }
                         Screen.Help -> HelpScreen()
                     }

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -22,4 +22,14 @@
     <string name="action_send">Send</string>
     <string name="msg_no_contacts">No contacts added</string>
     <string name="cd_add_contact">Add Contact</string>
+    <string name="title_generate_key">Generate Key Pair</string>
+    <string name="label_key_label">Key Label</string>
+    <string name="label_email">Email</string>
+    <string name="label_algorithm">Algorithm</string>
+    <string name="label_bit_length">Bit Length</string>
+    <string name="label_password">Password</string>
+    <string name="label_confirm_password">Confirm Password</string>
+    <string name="label_notes">Notes</string>
+    <string name="action_create">Create</string>
+    <string name="action_close">Close</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -22,4 +22,14 @@
     <string name="action_send">Enviar</string>
     <string name="msg_no_contacts">No hay contactos</string>
     <string name="cd_add_contact">Agregar contacto</string>
+    <string name="title_generate_key">Generar par de claves</string>
+    <string name="label_key_label">Etiqueta de clave</string>
+    <string name="label_email">Correo electrónico</string>
+    <string name="label_algorithm">Algoritmo</string>
+    <string name="label_bit_length">Longitud de bits</string>
+    <string name="label_password">Contraseña</string>
+    <string name="label_confirm_password">Confirmar contraseña</string>
+    <string name="label_notes">Notas</string>
+    <string name="action_create">Crear</string>
+    <string name="action_close">Cerrar</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -22,4 +22,14 @@
     <string name="action_send">Envoyer</string>
     <string name="msg_no_contacts">Aucun contact</string>
     <string name="cd_add_contact">Ajouter un contact</string>
+    <string name="title_generate_key">Générer une paire de clés</string>
+    <string name="label_key_label">Étiquette de clé</string>
+    <string name="label_email">E-mail</string>
+    <string name="label_algorithm">Algorithme</string>
+    <string name="label_bit_length">Longueur en bits</string>
+    <string name="label_password">Mot de passe</string>
+    <string name="label_confirm_password">Confirmer le mot de passe</string>
+    <string name="label_notes">Notes</string>
+    <string name="action_create">Créer</string>
+    <string name="action_close">Fermer</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -22,4 +22,14 @@
     <string name="action_send">Отправить</string>
     <string name="msg_no_contacts">Контакты отсутствуют</string>
     <string name="cd_add_contact">Добавить контакт</string>
+    <string name="title_generate_key">Создать пару ключей</string>
+    <string name="label_key_label">Метка ключа</string>
+    <string name="label_email">Эл. почта</string>
+    <string name="label_algorithm">Алгоритм</string>
+    <string name="label_bit_length">Длина ключа</string>
+    <string name="label_password">Пароль</string>
+    <string name="label_confirm_password">Подтвердите пароль</string>
+    <string name="label_notes">Заметки</string>
+    <string name="action_create">Создать</string>
+    <string name="action_close">Закрыть</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,14 @@
     <string name="action_send">Send</string>
     <string name="msg_no_contacts">No contacts added</string>
     <string name="cd_add_contact">Add Contact</string>
+    <string name="title_generate_key">Generate Key Pair</string>
+    <string name="label_key_label">Key Label</string>
+    <string name="label_email">Email</string>
+    <string name="label_algorithm">Algorithm</string>
+    <string name="label_bit_length">Bit Length</string>
+    <string name="label_password">Password</string>
+    <string name="label_confirm_password">Confirm Password</string>
+    <string name="label_notes">Notes</string>
+    <string name="action_create">Create</string>
+    <string name="action_close">Close</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `KeyGenerationDialog` composable to collect info for new PGP key pairs
- open the dialog from the floating action button on `KeyListScreen`
- update navigation to use revised `KeyListScreen`
- add string resources for the dialog in all languages

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577dfc92e0832d8a9e223a780f06dd