### PR TITLE
Add advanced accordion to key generation form

### DIFF
--- a/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
@@ -1,8 +1,13 @@
 package com.example.pgpandy
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -36,6 +41,7 @@ fun KeyGenerationDialog(
     var algorithmExpanded by remember { mutableStateOf(false) }
     var bitLength by remember { mutableStateOf(2048) }
     var bitExpanded by remember { mutableStateOf(false) }
+    var advancedExpanded by remember { mutableStateOf(false) }
     var password by remember { mutableStateOf("") }
     var confirmPassword by remember { mutableStateOf("") }
     var notes by remember { mutableStateOf("") }
@@ -91,86 +97,113 @@ fun KeyGenerationDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                ExposedDropdownMenuBox(
-                    expanded = algorithmExpanded,
-                    onExpandedChange = { algorithmExpanded = !algorithmExpanded }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { advancedExpanded = !advancedExpanded }
+                        .padding(vertical = 8.dp)
                 ) {
-                    OutlinedTextField(
-                        value = algorithm,
-                        onValueChange = {},
-                        readOnly = true,
-                        label = { Text(stringResource(R.string.label_algorithm)) },
-                        trailingIcon = {
-                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = algorithmExpanded)
-                        },
-                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    Text(
+                        text = stringResource(R.string.label_advanced),
+                        modifier = Modifier.weight(1f)
                     )
-                    ExposedDropdownMenu(
-                        expanded = algorithmExpanded,
-                        onDismissRequest = { algorithmExpanded = false }
-                    ) {
-                        algorithms.forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(option) },
-                                onClick = {
-                                    algorithm = option
-                                    algorithmExpanded = false
-                                }
-                            )
-                        }
-                    }
+                    Icon(
+                        imageVector = if (advancedExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                        contentDescription = null
+                    )
                 }
 
-                ExposedDropdownMenuBox(
-                    expanded = bitExpanded,
-                    onExpandedChange = { bitExpanded = !bitExpanded }
-                ) {
-                    OutlinedTextField(
-                        value = bitLength.toString(),
-                        onValueChange = {},
-                        readOnly = true,
-                        label = { Text(stringResource(R.string.label_bit_length)) },
-                        trailingIcon = {
-                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = bitExpanded)
-                        },
-                        modifier = Modifier.menuAnchor().fillMaxWidth()
-                    )
-                    ExposedDropdownMenu(
-                        expanded = bitExpanded,
-                        onDismissRequest = { bitExpanded = false }
-                    ) {
-                        bitOptions.forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(option.toString()) },
-                                onClick = {
-                                    bitLength = option
-                                    bitExpanded = false
+                if (advancedExpanded) {
+                    Column {
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            ExposedDropdownMenuBox(
+                                expanded = algorithmExpanded,
+                                onExpandedChange = { algorithmExpanded = !algorithmExpanded },
+                                modifier = Modifier.weight(1f).padding(end = 4.dp)
+                            ) {
+                                OutlinedTextField(
+                                    value = algorithm,
+                                    onValueChange = {},
+                                    readOnly = true,
+                                    label = { Text(stringResource(R.string.label_algorithm)) },
+                                    trailingIcon = {
+                                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = algorithmExpanded)
+                                    },
+                                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                                )
+                                ExposedDropdownMenu(
+                                    expanded = algorithmExpanded,
+                                    onDismissRequest = { algorithmExpanded = false }
+                                ) {
+                                    algorithms.forEach { option ->
+                                        DropdownMenuItem(
+                                            text = { Text(option) },
+                                            onClick = {
+                                                algorithm = option
+                                                algorithmExpanded = false
+                                            }
+                                        )
+                                    }
                                 }
+                            }
+
+                            ExposedDropdownMenuBox(
+                                expanded = bitExpanded,
+                                onExpandedChange = { bitExpanded = !bitExpanded },
+                                modifier = Modifier.weight(1f).padding(start = 4.dp)
+                            ) {
+                                OutlinedTextField(
+                                    value = bitLength.toString(),
+                                    onValueChange = {},
+                                    readOnly = true,
+                                    label = { Text(stringResource(R.string.label_bit_length)) },
+                                    trailingIcon = {
+                                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = bitExpanded)
+                                    },
+                                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                                )
+                                ExposedDropdownMenu(
+                                    expanded = bitExpanded,
+                                    onDismissRequest = { bitExpanded = false }
+                                ) {
+                                    bitOptions.forEach { option ->
+                                        DropdownMenuItem(
+                                            text = { Text(option.toString()) },
+                                            onClick = {
+                                                bitLength = option
+                                                bitExpanded = false
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            OutlinedTextField(
+                                value = password,
+                                onValueChange = { password = it },
+                                label = { Text(stringResource(R.string.label_password)) },
+                                modifier = Modifier.weight(1f).padding(end = 4.dp),
+                                visualTransformation = PasswordVisualTransformation()
+                            )
+                            OutlinedTextField(
+                                value = confirmPassword,
+                                onValueChange = { confirmPassword = it },
+                                label = { Text(stringResource(R.string.label_confirm_password)) },
+                                modifier = Modifier.weight(1f).padding(start = 4.dp),
+                                visualTransformation = PasswordVisualTransformation()
                             )
                         }
+
+                        OutlinedTextField(
+                            value = notes,
+                            onValueChange = { notes = it },
+                            label = { Text(stringResource(R.string.label_notes)) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
                 }
-
-                OutlinedTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    label = { Text(stringResource(R.string.label_password)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    visualTransformation = PasswordVisualTransformation()
-                )
-                OutlinedTextField(
-                    value = confirmPassword,
-                    onValueChange = { confirmPassword = it },
-                    label = { Text(stringResource(R.string.label_confirm_password)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    visualTransformation = PasswordVisualTransformation()
-                )
-                OutlinedTextField(
-                    value = notes,
-                    onValueChange = { notes = it },
-                    label = { Text(stringResource(R.string.label_notes)) },
-                    modifier = Modifier.fillMaxWidth()
-                )
             }
         }
     )

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -25,6 +25,7 @@
     <string name="title_generate_key">Generate Key Pair</string>
     <string name="label_key_label">Key Label</string>
     <string name="label_email">Email</string>
+    <string name="label_advanced">Advanced</string>
     <string name="label_algorithm">Algorithm</string>
     <string name="label_bit_length">Bit Length</string>
     <string name="label_password">Password</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -25,6 +25,7 @@
     <string name="title_generate_key">Generar par de claves</string>
     <string name="label_key_label">Etiqueta de clave</string>
     <string name="label_email">Correo electrónico</string>
+    <string name="label_advanced">Avanzado</string>
     <string name="label_algorithm">Algoritmo</string>
     <string name="label_bit_length">Longitud de bits</string>
     <string name="label_password">Contraseña</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,6 +25,7 @@
     <string name="title_generate_key">Générer une paire de clés</string>
     <string name="label_key_label">Étiquette de clé</string>
     <string name="label_email">E-mail</string>
+    <string name="label_advanced">Avancé</string>
     <string name="label_algorithm">Algorithme</string>
     <string name="label_bit_length">Longueur en bits</string>
     <string name="label_password">Mot de passe</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,6 +25,7 @@
     <string name="title_generate_key">Создать пару ключей</string>
     <string name="label_key_label">Метка ключа</string>
     <string name="label_email">Эл. почта</string>
+    <string name="label_advanced">Дополнительно</string>
     <string name="label_algorithm">Алгоритм</string>
     <string name="label_bit_length">Длина ключа</string>
     <string name="label_password">Пароль</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="title_generate_key">Generate Key Pair</string>
     <string name="label_key_label">Key Label</string>
     <string name="label_email">Email</string>
+    <string name="label_advanced">Advanced</string>
     <string name="label_algorithm">Algorithm</string>
     <string name="label_bit_length">Bit Length</string>
     <string name="label_password">Password</string>


### PR DESCRIPTION
## Summary
- add an expandable Advanced section to KeyGenerationDialog
- place algorithm and bit length side by side
- place password and confirm password side by side
- add `label_advanced` string with translations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685780470f44832dbb55d761f4d739c0