### PR TITLE
Preserve state on rotation

### DIFF
--- a/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -36,17 +37,17 @@ fun KeyGenerationDialog(
     onDismiss: () -> Unit,
     onCreate: (KeyFormData) -> Unit = {}
 ) {
-    var label by remember { mutableStateOf("") }
-    var name by remember { mutableStateOf("") }
-    var email by remember { mutableStateOf("") }
-    var algorithm by remember { mutableStateOf("RSA") }
+    var label by rememberSaveable { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf("") }
+    var email by rememberSaveable { mutableStateOf("") }
+    var algorithm by rememberSaveable { mutableStateOf("RSA") }
     var algorithmExpanded by remember { mutableStateOf(false) }
-    var bitLength by remember { mutableStateOf(2048) }
+    var bitLength by rememberSaveable { mutableStateOf(2048) }
     var bitExpanded by remember { mutableStateOf(false) }
-    var advancedExpanded by remember { mutableStateOf(false) }
-    var password by remember { mutableStateOf("") }
-    var confirmPassword by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
+    var advancedExpanded by rememberSaveable { mutableStateOf(false) }
+    var password by rememberSaveable { mutableStateOf("") }
+    var confirmPassword by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
 
     val algorithms = listOf("RSA", "DSA", "ECDSA", "EdDSA")
     val bitOptions = listOf(2048, 3072, 4096)

--- a/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.Box
@@ -16,7 +17,7 @@ import androidx.compose.ui.graphics.Color
 
 @Composable
 fun KeyListScreen() {
-    var showDialog by remember { mutableStateOf(false) }
+    var showDialog by rememberSaveable { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Text("No private keys added.", modifier = Modifier.align(Alignment.Center))

--- a/app/src/main/java/com/example/pgpandy/MainActivity.kt
+++ b/app/src/main/java/com/example/pgpandy/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.unit.dp
@@ -51,7 +52,7 @@ fun PGPAndyApp(initialLanguageTag: String) {
     var languageTag by remember { mutableStateOf(initialLanguageTag) }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
-    var screen by remember { mutableStateOf(Screen.ContactList) }
+    var screen by rememberSaveable { mutableStateOf(Screen.ContactList) }
     var languageMenuExpanded by remember { mutableStateOf(false) }
     val context = LocalContext.current
 


### PR DESCRIPTION
## Summary
- keep selected screen during configuration changes
- keep key list dialog visible across rotation
- remember key pair form fields so rotating doesn't clear them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68578838bae0832d88c43ebb468715a6