### PR TITLE
Add private key import

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,4 +50,6 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.9.0'
     implementation 'androidx.compose.foundation:foundation'
     implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
+    implementation 'org.bouncycastle:bcpg-jdk18on:1.80'
 }

--- a/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
@@ -87,4 +87,28 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DB_NAME, null
             SQLiteDatabase.CONFLICT_REPLACE
         )
     }
+
+    /**
+     * Inserts a parsed PGP key into the database.
+     */
+    fun insertKey(info: PgpKeyInfo) {
+        val values = ContentValues().apply {
+            put("user_id", info.userId)
+            put("fingerprint", info.fingerprint)
+            put("key_id", info.keyId)
+            put("is_private", if (info.isPrivate) 1 else 0)
+            put("armored_key", info.armoredKey)
+            put("algorithm", info.algorithm)
+            put("bit_length", info.bitLength)
+            put("comment", info.comment)
+            put("created_at", info.createdAt)
+            put("expires_at", info.expiresAt)
+        }
+        writableDatabase.insertWithOnConflict(
+            "pgp_keys",
+            null,
+            values,
+            SQLiteDatabase.CONFLICT_REPLACE
+        )
+    }
 }

--- a/app/src/main/java/com/example/pgpandy/KeyImportService.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyImportService.kt
@@ -1,0 +1,84 @@
+package com.example.pgpandy
+
+import android.content.Context
+import org.bouncycastle.openpgp.PGPObjectFactory
+import org.bouncycastle.openpgp.PGPSecretKeyRing
+import org.bouncycastle.openpgp.PGPPublicKeyRing
+import org.bouncycastle.openpgp.PGPUtil
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+
+/** Service class responsible for importing PGP keys from ASCII armored files. */
+class KeyImportService(private val context: Context) {
+
+    /**
+     * Parses the provided ASCII armored key data and inserts it into the local
+     * database. The method extracts some basic metadata such as fingerprint and
+     * user id using BouncyCastle.
+     */
+    fun importArmoredKey(armored: String) {
+        val decoder = PGPUtil.getDecoderStream(armored.byteInputStream())
+        val factory = PGPObjectFactory(decoder, JcaKeyFingerprintCalculator())
+        var keyRing: Any? = null
+        while (true) {
+            val obj = factory.nextObject() ?: break
+            if (obj is PGPSecretKeyRing || obj is PGPPublicKeyRing) {
+                keyRing = obj
+                break
+            }
+        }
+        if (keyRing == null) return
+
+        val isPrivate = keyRing is PGPSecretKeyRing
+        val pubKey = when (keyRing) {
+            is PGPSecretKeyRing -> keyRing.publicKey
+            is PGPPublicKeyRing -> keyRing.publicKey
+            else -> return
+        }
+
+        val fingerprint = pubKey.fingerprint.joinToString("") { "%02X".format(it) }
+        val keyId = java.lang.Long.toHexString(pubKey.keyID).uppercase()
+        val userId = pubKey.userIDs.asSequence().firstOrNull()
+        val algorithm = algorithmName(pubKey.algorithm)
+        val bitLength = pubKey.bitStrength()
+        val createdAt = pubKey.creationTime.time / 1000
+        val expiresAt = if (pubKey.validSeconds > 0) createdAt + pubKey.validSeconds else null
+
+        val info = PgpKeyInfo(
+            userId = userId,
+            fingerprint = fingerprint,
+            keyId = keyId,
+            isPrivate = isPrivate,
+            armoredKey = armored,
+            algorithm = algorithm,
+            bitLength = bitLength,
+            comment = null,
+            createdAt = createdAt,
+            expiresAt = expiresAt
+        )
+        DatabaseHelper(context).insertKey(info)
+    }
+
+    private fun algorithmName(tag: Int): String {
+        return when (tag) {
+            1, 2, 3 -> "RSA"
+            17 -> "DSA"
+            19 -> "ECDSA"
+            22 -> "EdDSA"
+            else -> "Unknown"
+        }
+    }
+}
+
+/** Simple data holder used when inserting a key into the database. */
+data class PgpKeyInfo(
+    val userId: String?,
+    val fingerprint: String,
+    val keyId: String,
+    val isPrivate: Boolean,
+    val armoredKey: String,
+    val algorithm: String?,
+    val bitLength: Int?,
+    val comment: String?,
+    val createdAt: Long?,
+    val expiresAt: Long?
+)

--- a/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
@@ -1,5 +1,7 @@
 package com.example.pgpandy
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -12,15 +14,41 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 
 @Composable
 fun KeyListScreen() {
     var showDialog by rememberSaveable { mutableStateOf(false) }
+    val context = LocalContext.current
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let {
+            context.contentResolver.openInputStream(it)?.use { stream ->
+                val armored = stream.bufferedReader().readText()
+                KeyImportService(context).importArmoredKey(armored)
+            }
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Text("No private keys added.", modifier = Modifier.align(Alignment.Center))
+
+        FloatingActionButton(
+            onClick = { importLauncher.launch(arrayOf("*/*")) },
+            modifier = Modifier.align(Alignment.BottomStart).padding(16.dp),
+            containerColor = Color(0xFF440020),
+            contentColor = Color.White
+        ) {
+            Icon(
+                Icons.Default.FileOpen,
+                contentDescription = stringResource(R.string.cd_import_key)
+            )
+        }
 
         FloatingActionButton(
             onClick = { showDialog = true },

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -33,4 +33,6 @@
     <string name="label_notes">Embedded Notes</string>
     <string name="action_create">Create</string>
     <string name="action_close">Close</string>
+    <string name="action_import">Import</string>
+    <string name="cd_import_key">Import Key</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -33,4 +33,6 @@
     <string name="label_notes">Notas</string>
     <string name="action_create">Crear</string>
     <string name="action_close">Cerrar</string>
+    <string name="action_import">Importar</string>
+    <string name="cd_import_key">Importar clave</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,4 +33,6 @@
     <string name="label_notes">Notes</string>
     <string name="action_create">Créer</string>
     <string name="action_close">Fermer</string>
+    <string name="action_import">Importer</string>
+    <string name="cd_import_key">Importer la clé</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -33,4 +33,6 @@
     <string name="label_notes">Заметки</string>
     <string name="action_create">Создать</string>
     <string name="action_close">Закрыть</string>
+    <string name="action_import">Импорт</string>
+    <string name="cd_import_key">Импортировать ключ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
     <string name="label_notes">Embedded Notes</string>
     <string name="action_create">Create</string>
     <string name="action_close">Close</string>
+    <string name="action_import">Import</string>
+    <string name="cd_import_key">Import Key</string>
 </resources>


### PR DESCRIPTION
## Summary
- add KeyImportService for parsing PGP keys using BouncyCastle
- persist key data with new `insertKey` helper
- allow importing `.asc` files from the Private Keys screen
- add string resources for the import action
- include BouncyCastle dependencies

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685875550640832dbba0977b5df9d3fc