### PR TITLE
Enable key creation and persistence

### DIFF
--- a/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyGenerationDialog.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.platform.LocalContext
+import com.example.pgpandy.KeyGenerationService
 
 /** Data container for the key generation form fields. */
 data class KeyFormData(
@@ -52,12 +54,16 @@ fun KeyGenerationDialog(
     val algorithms = listOf("RSA", "DSA", "ECDSA", "EdDSA")
     val bitOptions = listOf(2048, 3072, 4096)
 
+    val context = LocalContext.current
+    val formValid = label.isNotBlank() && (name.isNotBlank() || email.isNotBlank())
+
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
-            TextButton(onClick = {
-                onCreate(
-                    KeyFormData(
+            TextButton(
+                enabled = formValid,
+                onClick = {
+                    val data = KeyFormData(
                         label,
                         name,
                         email,
@@ -67,9 +73,11 @@ fun KeyGenerationDialog(
                         confirmPassword,
                         notes
                     )
-                )
-                onDismiss()
-            }) {
+                    KeyGenerationService(context).generateAndStore(data)
+                    onCreate(data)
+                    onDismiss()
+                }
+            ) {
                 Text(stringResource(R.string.action_create))
             }
         },

--- a/app/src/main/java/com/example/pgpandy/KeyGenerationService.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyGenerationService.kt
@@ -1,0 +1,111 @@
+package com.example.pgpandy
+
+import android.content.Context
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.security.KeyPairGenerator
+import java.security.Security
+import java.security.SecureRandom
+import java.util.Date
+import org.bouncycastle.bcpg.ArmoredOutputStream
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openpgp.*
+import org.bouncycastle.openpgp.operator.jcajce.*
+
+class KeyGenerationService(private val context: Context) {
+    fun generateAndStore(data: KeyFormData) {
+        val identity = buildIdentity(data.name, data.email)
+        val pass = if (data.password.isNotEmpty()) data.password.toCharArray() else CharArray(0)
+        val armored = generateRsaSecretKey(data.bitLength, identity, pass)
+        val info = parseInfo(armored)
+        if (info != null) {
+            val withComment = info.copy(comment = data.label)
+            DatabaseHelper(context).insertKey(withComment)
+        }
+    }
+
+    private fun buildIdentity(name: String, email: String): String {
+        val parts = mutableListOf<String>()
+        if (name.isNotBlank()) parts.add(name.trim())
+        if (email.isNotBlank()) parts.add("<${email.trim()}>")
+        return parts.joinToString(" ")
+    }
+
+    private fun generateRsaSecretKey(bitLength: Int, identity: String, passphrase: CharArray): String {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(BouncyCastleProvider())
+        }
+        val kpg = KeyPairGenerator.getInstance("RSA", "BC")
+        kpg.initialize(bitLength, SecureRandom())
+        val kp = kpg.generateKeyPair()
+        val pgpKp = JcaPGPKeyPair(PGPPublicKey.RSA_GENERAL, kp, Date())
+        val sha1Calc = JcaPGPDigestCalculatorProviderBuilder().build().get(HashAlgorithmTags.SHA1)
+        val contentSigner = JcaPGPContentSignerBuilder(pgpKp.publicKey.algorithm, HashAlgorithmTags.SHA256).setProvider("BC")
+        val encryptor = JcePBESecretKeyEncryptorBuilder(PGPEncryptedData.AES_256, sha1Calc)
+            .setProvider("BC")
+            .build(passphrase)
+        val keyRingGen = PGPKeyRingGenerator(
+            PGPSignature.POSITIVE_CERTIFICATION,
+            pgpKp,
+            identity,
+            sha1Calc,
+            null,
+            null,
+            contentSigner,
+            encryptor
+        )
+        val secretRing = keyRingGen.generateSecretKeyRing()
+        val out = ByteArrayOutputStream()
+        ArmoredOutputStream(out).use { secretRing.encode(it) }
+        return out.toString(StandardCharsets.UTF_8.name())
+    }
+
+    private fun parseInfo(armored: String): PgpKeyInfo? {
+        val decoder = PGPUtil.getDecoderStream(armored.byteInputStream())
+        val factory = PGPObjectFactory(decoder, JcaKeyFingerprintCalculator())
+        var keyRing: Any? = null
+        while (true) {
+            val obj = factory.nextObject() ?: break
+            if (obj is PGPSecretKeyRing || obj is PGPPublicKeyRing) {
+                keyRing = obj
+                break
+            }
+        }
+        if (keyRing == null) return null
+        val isPrivate = keyRing is PGPSecretKeyRing
+        val pubKey = when (keyRing) {
+            is PGPSecretKeyRing -> keyRing.publicKey
+            is PGPPublicKeyRing -> keyRing.publicKey
+            else -> return null
+        }
+        val fingerprint = pubKey.fingerprint.joinToString("") { "%02X".format(it) }
+        val keyId = java.lang.Long.toHexString(pubKey.keyID).uppercase()
+        val userId = pubKey.userIDs.asSequence().firstOrNull()
+        val algorithm = algorithmName(pubKey.algorithm)
+        val bitLength = pubKey.bitStrength()
+        val createdAt = pubKey.creationTime.time / 1000
+        val expiresAt = if (pubKey.validSeconds > 0) createdAt + pubKey.validSeconds else null
+        return PgpKeyInfo(
+            userId = userId,
+            fingerprint = fingerprint,
+            keyId = keyId,
+            isPrivate = isPrivate,
+            armoredKey = armored,
+            algorithm = algorithm,
+            bitLength = bitLength,
+            comment = null,
+            createdAt = createdAt,
+            expiresAt = expiresAt
+        )
+    }
+
+    private fun algorithmName(tag: Int): String {
+        return when (tag) {
+            1, 2, 3 -> "RSA"
+            17 -> "DSA"
+            19 -> "ECDSA"
+            22 -> "EdDSA"
+            else -> "Unknown"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `KeyGenerationService` to generate RSA keys and store info
- ensure key generation form uses service and validates required fields

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589f34cac4832d9c7e62944efba158