### PR TITLE
Add private key list view

### DIFF
--- a/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/pgpandy/DatabaseHelper.kt
@@ -111,4 +111,40 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DB_NAME, null
             SQLiteDatabase.CONFLICT_REPLACE
         )
     }
+
+    /**
+     * Returns all private keys stored in the database.
+     */
+    fun getPrivateKeys(): List<PgpKeyInfo> {
+        val keys = mutableListOf<PgpKeyInfo>()
+        readableDatabase.rawQuery(
+            "SELECT user_id, fingerprint, key_id, is_private, armored_key, algorithm, bit_length, comment, created_at, expires_at FROM pgp_keys WHERE is_private = 1",
+            null
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                keys.add(
+                    PgpKeyInfo(
+                        userId = cursor.getString(0),
+                        fingerprint = cursor.getString(1),
+                        keyId = cursor.getString(2),
+                        isPrivate = cursor.getInt(3) == 1,
+                        armoredKey = cursor.getString(4),
+                        algorithm = cursor.getString(5),
+                        bitLength = if (cursor.isNull(6)) null else cursor.getInt(6),
+                        comment = cursor.getString(7),
+                        createdAt = if (cursor.isNull(8)) null else cursor.getLong(8),
+                        expiresAt = if (cursor.isNull(9)) null else cursor.getLong(9)
+                    )
+                )
+            }
+        }
+        return keys
+    }
+
+    /**
+     * Deletes a key by its fingerprint.
+     */
+    fun deleteKey(fingerprint: String) {
+        writableDatabase.delete("pgp_keys", "fingerprint = ?", arrayOf(fingerprint))
+    }
 }

--- a/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/com/example/pgpandy/KeyListScreen.kt
@@ -2,20 +2,24 @@ package com.example.pgpandy
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.shadow
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.ui.unit.dp
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -24,6 +28,13 @@ import androidx.compose.ui.res.stringResource
 fun KeyListScreen() {
     var showDialog by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
+    var keys by remember { mutableStateOf(listOf<PgpKeyInfo>()) }
+
+    fun refresh() {
+        keys = DatabaseHelper(context).getPrivateKeys()
+    }
+
+    LaunchedEffect(Unit) { refresh() }
     val importLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocument()
     ) { uri ->
@@ -31,12 +42,44 @@ fun KeyListScreen() {
             context.contentResolver.openInputStream(it)?.use { stream ->
                 val armored = stream.bufferedReader().readText()
                 KeyImportService(context).importArmoredKey(armored)
+                refresh()
             }
         }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Text("No private keys added.", modifier = Modifier.align(Alignment.Center))
+        if (keys.isEmpty()) {
+            Text(stringResource(R.string.msg_no_private_keys), modifier = Modifier.align(Alignment.Center))
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(keys) { key ->
+                    Card(
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .fillMaxWidth()
+                            .shadow(2.dp, RoundedCornerShape(8.dp)),
+                        colors = CardDefaults.cardColors()
+                    ) {
+                        Row(modifier = Modifier.fillMaxWidth().padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(text = key.comment ?: key.userId ?: key.fingerprint.take(8))
+                                key.createdAt?.let {
+                                    val date = Date(it * 1000)
+                                    val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                                    Text(fmt.format(date))
+                                }
+                            }
+                            IconButton(onClick = {
+                                DatabaseHelper(context).deleteKey(key.fingerprint)
+                                refresh()
+                            }) {
+                                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.cd_delete_key))
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         FloatingActionButton(
             onClick = { importLauncher.launch(arrayOf("*/*")) },
@@ -60,7 +103,7 @@ fun KeyListScreen() {
         }
 
         if (showDialog) {
-            KeyGenerationDialog(onDismiss = { showDialog = false })
+            KeyGenerationDialog(onDismiss = { showDialog = false; refresh() })
         }
     }
 }

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -35,4 +35,6 @@
     <string name="action_close">Cerrar</string>
     <string name="action_import">Importar</string>
     <string name="cd_import_key">Importar clave</string>
+    <string name="msg_no_private_keys">Aún no hay claves privadas</string>
+    <string name="cd_delete_key">Eliminar clave</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,4 +35,6 @@
     <string name="action_close">Fermer</string>
     <string name="action_import">Importer</string>
     <string name="cd_import_key">Importer la clé</string>
+    <string name="msg_no_private_keys">Aucune clé privée</string>
+    <string name="cd_delete_key">Supprimer la clé</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -35,4 +35,6 @@
     <string name="action_close">Закрыть</string>
     <string name="action_import">Импорт</string>
     <string name="cd_import_key">Импортировать ключ</string>
+    <string name="msg_no_private_keys">Пока нет приватных ключей</string>
+    <string name="cd_delete_key">Удалить ключ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,6 @@
     <string name="action_close">Close</string>
     <string name="action_import">Import</string>
     <string name="cd_import_key">Import Key</string>
+    <string name="msg_no_private_keys">No private keys yet.</string>
+    <string name="cd_delete_key">Delete key</string>
 </resources>


### PR DESCRIPTION
## Summary
- show private keys from database in scrollable list
- support deleting a key
- translate new strings
- provide DB helpers for querying and deleting keys

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858c0ce0ea4832db04b4de20d9532ee