### PR TITLE
Add key detail modal and delete confirmation

### DIFF
--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -35,4 +35,8 @@
     <string name="action_close">Close</string>
     <string name="action_import">Import</string>
     <string name="cd_import_key">Import Key</string>
+    <string name="confirm_delete_key">Delete this key?</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_copy">Copy to Clipboard</string>
+    <string name="title_private_key">Private Key</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -37,4 +37,8 @@
     <string name="cd_import_key">Importar clave</string>
     <string name="msg_no_private_keys">Aún no hay claves privadas</string>
     <string name="cd_delete_key">Eliminar clave</string>
+    <string name="confirm_delete_key">¿Eliminar esta clave?</string>
+    <string name="action_delete">Eliminar</string>
+    <string name="action_copy">Copiar al portapapeles</string>
+    <string name="title_private_key">Clave privada</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -37,4 +37,8 @@
     <string name="cd_import_key">Importer la clé</string>
     <string name="msg_no_private_keys">Aucune clé privée</string>
     <string name="cd_delete_key">Supprimer la clé</string>
+    <string name="confirm_delete_key">Supprimer cette clé ?</string>
+    <string name="action_delete">Supprimer</string>
+    <string name="action_copy">Copier dans le presse-papiers</string>
+    <string name="title_private_key">Clé privée</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,4 +37,8 @@
     <string name="cd_import_key">Импортировать ключ</string>
     <string name="msg_no_private_keys">Пока нет приватных ключей</string>
     <string name="cd_delete_key">Удалить ключ</string>
+    <string name="confirm_delete_key">Удалить этот ключ?</string>
+    <string name="action_delete">Удалить</string>
+    <string name="action_copy">Копировать в буфер</string>
+    <string name="title_private_key">Приватный ключ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,8 @@
     <string name="cd_import_key">Import Key</string>
     <string name="msg_no_private_keys">No private keys yet.</string>
     <string name="cd_delete_key">Delete key</string>
+    <string name="confirm_delete_key">Delete this key?</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_copy">Copy to Clipboard</string>
+    <string name="title_private_key">Private Key</string>
 </resources>


### PR DESCRIPTION
## Summary
- add clipboard and scroll imports to KeyListScreen
- show dialogs for deleting and viewing keys
- localize strings for the new dialog actions

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cef8ce40832db533538cd40c8d01