### PR TITLE
Show public key in key viewer

### DIFF
--- a/app/src/main/java/engineer/warfare/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/KeyListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
+import engineer.warfare.pgpandy.PgpKeyUtils
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -123,9 +124,12 @@ fun KeyListScreen(isDarkTheme: Boolean) {
                         Text(stringResource(R.string.action_close))
                     }
                 },
-                title = { Text(stringResource(R.string.title_private_key)) },
+                title = { Text(stringResource(R.string.title_public_key)) },
                 text = {
                     val clipboardManager = LocalClipboardManager.current
+                    val publicKey = remember(viewKey) {
+                        PgpKeyUtils.extractPublicKey(viewKey.armoredKey) ?: ""
+                    }
 
                     Column(modifier = Modifier.fillMaxWidth()) {
                         Box(
@@ -136,7 +140,7 @@ fun KeyListScreen(isDarkTheme: Boolean) {
                                 .verticalScroll(rememberScrollState())
                         ) {
                             Text(
-                                text = viewKey.armoredKey,
+                                text = publicKey,
                                 fontSize = 12.sp,
                                 color = if (isDarkTheme) Color.White else Color.Black
                             )
@@ -146,14 +150,28 @@ fun KeyListScreen(isDarkTheme: Boolean) {
 
                         Button(
                             onClick = {
-                                clipboardManager.setText(AnnotatedString(viewKey.armoredKey))
+                                clipboardManager.setText(AnnotatedString(publicKey))
                             },
                             modifier = Modifier.align(Alignment.CenterHorizontally),
                             shape = RoundedCornerShape(3.dp) // 👈 Rounded corners
                         ) {
                             Icon(Icons.Default.ContentCopy, contentDescription = null)
                             Spacer(Modifier.width(8.dp))
-                            Text(stringResource(R.string.action_copy))
+                            Text(stringResource(R.string.action_copy_public_key))
+                        }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Button(
+                            onClick = {
+                                clipboardManager.setText(AnnotatedString(viewKey.armoredKey))
+                            },
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            shape = RoundedCornerShape(3.dp)
+                        ) {
+                            Icon(Icons.Default.ContentCopy, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.action_copy_private_key))
                         }
                     }
                 }

--- a/app/src/main/java/engineer/warfare/pgpandy/PgpKeyUtils.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/PgpKeyUtils.kt
@@ -1,0 +1,44 @@
+package engineer.warfare.pgpandy
+
+import org.bouncycastle.bcpg.ArmoredOutputStream
+import org.bouncycastle.openpgp.*
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+
+/** Utility helpers for working with armored PGP keys. */
+object PgpKeyUtils {
+    /**
+     * Extracts the ASCII armored public key portion from the provided armored key.
+     * The input can be either a public or private key block. Returns null if
+     * parsing fails.
+     */
+    fun extractPublicKey(armored: String): String? {
+        val decoder = PGPUtil.getDecoderStream(armored.byteInputStream())
+        val factory = PGPObjectFactory(decoder, JcaKeyFingerprintCalculator())
+        var keyRing: Any? = null
+        while (true) {
+            val obj = factory.nextObject() ?: break
+            if (obj is PGPSecretKeyRing || obj is PGPPublicKeyRing) {
+                keyRing = obj
+                break
+            }
+        }
+        if (keyRing == null) return null
+        val publicRing = when (keyRing) {
+            is PGPSecretKeyRing -> {
+                val keys = mutableListOf<PGPPublicKey>()
+                val it = keyRing.publicKeys
+                while (it.hasNext()) {
+                    keys.add(it.next() as PGPPublicKey)
+                }
+                PGPPublicKeyRing(keys)
+            }
+            is PGPPublicKeyRing -> keyRing
+            else -> return null
+        }
+        val out = ByteArrayOutputStream()
+        ArmoredOutputStream(out).use { publicRing.encode(it) }
+        return out.toString(StandardCharsets.UTF_8.name())
+    }
+}

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -39,4 +39,7 @@
     <string name="action_delete">Delete</string>
     <string name="action_copy">Copy to Clipboard</string>
     <string name="title_private_key">Private Key</string>
+    <string name="title_public_key">Public Key</string>
+    <string name="action_copy_public_key">Copy Public Key</string>
+    <string name="action_copy_private_key">Copy Private Key</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -41,4 +41,7 @@
     <string name="action_delete">Eliminar</string>
     <string name="action_copy">Copiar al portapapeles</string>
     <string name="title_private_key">Clave privada</string>
+    <string name="title_public_key">Clave pública</string>
+    <string name="action_copy_public_key">Copiar clave pública</string>
+    <string name="action_copy_private_key">Copiar clave privada</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,4 +41,7 @@
     <string name="action_delete">Supprimer</string>
     <string name="action_copy">Copier dans le presse-papiers</string>
     <string name="title_private_key">Clé privée</string>
+    <string name="title_public_key">Clé publique</string>
+    <string name="action_copy_public_key">Copier la clé publique</string>
+    <string name="action_copy_private_key">Copier la clé privée</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -41,4 +41,7 @@
     <string name="action_delete">Удалить</string>
     <string name="action_copy">Копировать в буфер</string>
     <string name="title_private_key">Приватный ключ</string>
+    <string name="title_public_key">Публичный ключ</string>
+    <string name="action_copy_public_key">Копировать публичный ключ</string>
+    <string name="action_copy_private_key">Копировать приватный ключ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,7 @@
     <string name="action_delete">Delete</string>
     <string name="action_copy">Copy to Clipboard</string>
     <string name="title_private_key">Private Key</string>
+    <string name="title_public_key">Public Key</string>
+    <string name="action_copy_public_key">Copy Public Key</string>
+    <string name="action_copy_private_key">Copy Private Key</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `PgpKeyUtils` to convert private key to public key
- update key viewer dialog to display public key and provide copy buttons
- add resources for new strings in all languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c7586935c832d83d5394d9021205b