### PR TITLE
Fix crash when importing non-asc key

### DIFF
--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -35,6 +35,7 @@
     <string name="action_close">Close</string>
     <string name="action_import">Import</string>
     <string name="cd_import_key">Import Key</string>
+    <string name="msg_invalid_key_file">Please select a valid .asc file</string>
     <string name="confirm_delete_key">Delete this key?</string>
     <string name="action_delete">Delete</string>
     <string name="action_copy">Copy to Clipboard</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Importar</string>
     <string name="cd_import_key">Importar clave</string>
     <string name="msg_no_private_keys">Aún no hay claves privadas</string>
+    <string name="msg_invalid_key_file">Seleccione un archivo .asc válido</string>
     <string name="cd_delete_key">Eliminar clave</string>
     <string name="confirm_delete_key">¿Eliminar esta clave?</string>
     <string name="action_delete">Eliminar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Importer</string>
     <string name="cd_import_key">Importer la clé</string>
     <string name="msg_no_private_keys">Aucune clé privée</string>
+    <string name="msg_invalid_key_file">Veuillez sélectionner un fichier .asc valide</string>
     <string name="cd_delete_key">Supprimer la clé</string>
     <string name="confirm_delete_key">Supprimer cette clé ?</string>
     <string name="action_delete">Supprimer</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Импорт</string>
     <string name="cd_import_key">Импортировать ключ</string>
     <string name="msg_no_private_keys">Пока нет приватных ключей</string>
+    <string name="msg_invalid_key_file">Пожалуйста, выберите корректный файл .asc</string>
     <string name="cd_delete_key">Удалить ключ</string>
     <string name="confirm_delete_key">Удалить этот ключ?</string>
     <string name="action_delete">Удалить</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Import</string>
     <string name="cd_import_key">Import Key</string>
     <string name="msg_no_private_keys">No private keys yet.</string>
+    <string name="msg_invalid_key_file">Please select a valid .asc file</string>
     <string name="cd_delete_key">Delete key</string>
     <string name="confirm_delete_key">Delete this key?</string>
     <string name="action_delete">Delete</string>


### PR DESCRIPTION
## Summary
- validate selected file before importing keys
- show an error when file extension is not `.asc`
- add localized string resources for invalid import files

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c788ad2b8832dbe16214bec5cea43