### PR TITLE
Handle multi-key imports

### DIFF
--- a/app/src/main/java/engineer/warfare/pgpandy/KeyListScreen.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/KeyListScreen.kt
@@ -70,10 +70,15 @@ fun KeyListScreen(isDarkTheme: Boolean) {
             context.contentResolver.openInputStream(it)?.use { stream ->
                 val armored = stream.bufferedReader().readText()
                 try {
-                    KeyImportService(context).importArmoredKey(armored)
-                    refresh()
-                } catch (_: Exception) {
-                    Toast.makeText(context, context.getString(R.string.msg_invalid_key_file), Toast.LENGTH_LONG).show()
+                    val imported = KeyImportService(context).importArmoredKey(armored)
+                    if (imported == 0) {
+                        Toast.makeText(context, context.getString(R.string.msg_no_keys_found), Toast.LENGTH_LONG).show()
+                    } else {
+                        refresh()
+                    }
+                } catch (e: Exception) {
+                    val msg = context.getString(R.string.msg_import_failed, e.message ?: "")
+                    Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
                 }
             }
         }

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -43,4 +43,6 @@
     <string name="title_public_key">Public Key</string>
     <string name="action_copy_public_key">Copy Public Key</string>
     <string name="action_copy_private_key">Copy Private Key</string>
+    <string name="msg_no_keys_found">No keys found in file</string>
+    <string name="msg_import_failed">Failed to import key: %1$s</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -45,4 +45,6 @@
     <string name="title_public_key">Clave pública</string>
     <string name="action_copy_public_key">Copiar clave pública</string>
     <string name="action_copy_private_key">Copiar clave privada</string>
+    <string name="msg_no_keys_found">No se encontraron claves en el archivo</string>
+    <string name="msg_import_failed">Error al importar clave: %1$s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,4 +45,6 @@
     <string name="title_public_key">Clé publique</string>
     <string name="action_copy_public_key">Copier la clé publique</string>
     <string name="action_copy_private_key">Copier la clé privée</string>
+    <string name="msg_no_keys_found">Aucune clé trouvée dans le fichier</string>
+    <string name="msg_import_failed">Échec de l\'importation de la clé : %1$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -45,4 +45,6 @@
     <string name="title_public_key">Публичный ключ</string>
     <string name="action_copy_public_key">Копировать публичный ключ</string>
     <string name="action_copy_private_key">Копировать приватный ключ</string>
+    <string name="msg_no_keys_found">В файле не найдено ключей</string>
+    <string name="msg_import_failed">Ошибка импорта ключа: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,6 @@
     <string name="title_public_key">Public Key</string>
     <string name="action_copy_public_key">Copy Public Key</string>
     <string name="action_copy_private_key">Copy Private Key</string>
+    <string name="msg_no_keys_found">No keys found in file</string>
+    <string name="msg_import_failed">Failed to import key: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- support multiple key rings when importing ASC files
- show error message toast when import fails
- add strings for empty key files and import failure

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c7e35b314832d8ad4a67b149ab759