### PR TITLE
Add public key import from contacts

### DIFF
--- a/app/src/main/java/engineer/warfare/pgpandy/ContactListScreen.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/ContactListScreen.kt
@@ -1,12 +1,15 @@
 package engineer.warfare.pgpandy
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import android.provider.OpenableColumns
+import android.widget.Toast
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material3.Divider
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -17,12 +20,53 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun ContactListScreen(onAddContact: () -> Unit) {
     val contacts = ContactRepository.contacts
+    val context = LocalContext.current
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let {
+            val fileName = context.contentResolver.query(
+                it,
+                arrayOf(OpenableColumns.DISPLAY_NAME),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx) else null
+            }
+
+            if (fileName == null || !fileName.endsWith(".asc", ignoreCase = true)) {
+                Toast.makeText(context, context.getString(R.string.msg_invalid_key_file), Toast.LENGTH_LONG).show()
+                return@let
+            }
+
+            context.contentResolver.openInputStream(it)?.use { stream ->
+                val armored = stream.bufferedReader().readText()
+                try {
+                    val imported = PublicKeyImportService(context).importPublicKeys(armored)
+                    if (imported == 0) {
+                        Toast.makeText(context, context.getString(R.string.msg_no_keys_found), Toast.LENGTH_LONG).show()
+                    }
+                } catch (e: Exception) {
+                    val msg = when (e.message) {
+                        "private" -> context.getString(R.string.msg_public_key_required)
+                        "none" -> context.getString(R.string.msg_no_keys_found)
+                        else -> context.getString(R.string.msg_import_failed, e.message ?: "")
+                    }
+                    Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (contacts.isEmpty()) {
@@ -46,6 +90,15 @@ fun ContactListScreen(onAddContact: () -> Unit) {
             contentColor = Color.White
         ) {
             Icon(Icons.Default.PersonAdd, contentDescription = stringResource(R.string.cd_add_contact))
+        }
+
+        FloatingActionButton(
+            onClick = { importLauncher.launch(arrayOf("*/*")) },
+            modifier = Modifier.align(Alignment.BottomStart).padding(16.dp),
+            containerColor = Color(0xFF440020),
+            contentColor = Color.White
+        ) {
+            Icon(Icons.Default.FileOpen, contentDescription = stringResource(R.string.cd_import_key))
         }
     }
 }

--- a/app/src/main/java/engineer/warfare/pgpandy/PublicKeyImportService.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/PublicKeyImportService.kt
@@ -1,0 +1,74 @@
+package engineer.warfare.pgpandy
+
+import android.content.Context
+import org.bouncycastle.openpgp.PGPObjectFactory
+import org.bouncycastle.openpgp.PGPPublicKeyRing
+import org.bouncycastle.openpgp.PGPSecretKeyRing
+import org.bouncycastle.openpgp.PGPUtil
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+
+/** Service for importing only public keys. Throws if a private key is found. */
+class PublicKeyImportService(private val context: Context) {
+    /**
+     * Parses ASCII armored data and inserts any public keys found. If a private
+     * key is encountered an exception is thrown.
+     * @return number of public keys imported
+     */
+    fun importPublicKeys(armored: String): Int {
+        val decoder = PGPUtil.getDecoderStream(armored.byteInputStream())
+        val factory = PGPObjectFactory(decoder, JcaKeyFingerprintCalculator())
+        var count = 0
+        var found = false
+        while (true) {
+            val obj = factory.nextObject() ?: break
+            when (obj) {
+                is PGPSecretKeyRing -> throw IllegalArgumentException("private")
+                is PGPPublicKeyRing -> {
+                    found = true
+                    val out = java.io.ByteArrayOutputStream()
+                    org.bouncycastle.bcpg.ArmoredOutputStream(out).use {
+                        obj.encode(it)
+                    }
+                    val ringArmored = out.toString(java.nio.charset.StandardCharsets.UTF_8.name())
+
+                    val pubKey = obj.publicKey
+                    val fingerprint = pubKey.fingerprint.joinToString("") { "%02X".format(it) }
+                    val keyId = java.lang.Long.toHexString(pubKey.keyID).uppercase()
+                    val userId = pubKey.userIDs.asSequence().firstOrNull()
+                    val algorithm = algorithmName(pubKey.algorithm)
+                    val bitLength = pubKey.bitStrength
+                    val createdAt = pubKey.creationTime.time / 1000
+                    val expiresAt = if (pubKey.validSeconds > 0) createdAt + pubKey.validSeconds else null
+
+                    val info = PgpKeyInfo(
+                        userId = userId,
+                        fingerprint = fingerprint,
+                        keyId = keyId,
+                        isPrivate = false,
+                        armoredKey = ringArmored,
+                        algorithm = algorithm,
+                        bitLength = bitLength,
+                        comment = null,
+                        createdAt = createdAt,
+                        expiresAt = expiresAt
+                    )
+                    DatabaseHelper(context).insertKey(info)
+                    count++
+                }
+            }
+        }
+        if (!found) throw IllegalArgumentException("none")
+        return count
+    }
+
+    private fun algorithmName(tag: Int): String {
+        return when (tag) {
+            1, 2, 3 -> "RSA"
+            17 -> "DSA"
+            19 -> "ECDSA"
+            22 -> "EdDSA"
+            else -> "Unknown"
+        }
+    }
+}
+

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -45,4 +45,5 @@
     <string name="action_copy_private_key">Copy Private Key</string>
     <string name="msg_no_keys_found">No keys found in file</string>
     <string name="msg_import_failed">Failed to import key: %1$s</string>
+    <string name="msg_public_key_required">File must contain a public key</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -47,4 +47,5 @@
     <string name="action_copy_private_key">Copiar clave privada</string>
     <string name="msg_no_keys_found">No se encontraron claves en el archivo</string>
     <string name="msg_import_failed">Error al importar clave: %1$s</string>
+    <string name="msg_public_key_required">El archivo debe contener una clave pública</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -47,4 +47,5 @@
     <string name="action_copy_private_key">Copier la clé privée</string>
     <string name="msg_no_keys_found">Aucune clé trouvée dans le fichier</string>
     <string name="msg_import_failed">Échec de l\'importation de la clé : %1$s</string>
+    <string name="msg_public_key_required">Le fichier doit contenir une clé publique</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -47,4 +47,5 @@
     <string name="action_copy_private_key">Копировать приватный ключ</string>
     <string name="msg_no_keys_found">В файле не найдено ключей</string>
     <string name="msg_import_failed">Ошибка импорта ключа: %1$s</string>
+    <string name="msg_public_key_required">Файл должен содержать публичный ключ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,5 @@
     <string name="action_copy_private_key">Copy Private Key</string>
     <string name="msg_no_keys_found">No keys found in file</string>
     <string name="msg_import_failed">Failed to import key: %1$s</string>
+    <string name="msg_public_key_required">File must contain a public key</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `PublicKeyImportService` for importing only public keys
- add floating import button on contacts screen
- translate new `msg_public_key_required` string in all languages

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c84252034832db5af62d49124794e