### PR TITLE
Add stored public key list

### DIFF
--- a/app/src/main/java/engineer/warfare/pgpandy/ContactListScreen.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/ContactListScreen.kt
@@ -1,38 +1,55 @@
 package engineer.warfare.pgpandy
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import android.provider.OpenableColumns
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.bouncycastle.openpgp.PGPObjectFactory
 import org.bouncycastle.openpgp.PGPPublicKeyRing
 import org.bouncycastle.openpgp.PGPSecretKeyRing
 import org.bouncycastle.openpgp.PGPUtil
 import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PersonAdd
-import androidx.compose.material.icons.filled.FileOpen
-import androidx.compose.material3.Divider
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
-fun ContactListScreen(onAddContact: () -> Unit) {
-    val contacts = ContactRepository.contacts
+fun ContactListScreen(isDarkTheme: Boolean, onAddContact: () -> Unit) {
+    var keys by remember { mutableStateOf(listOf<PgpKeyInfo>()) }
+    var keyToDelete by remember { mutableStateOf<PgpKeyInfo?>(null) }
+    var keyToView by remember { mutableStateOf<PgpKeyInfo?>(null) }
     val context = LocalContext.current
+
+    fun refresh() {
+        keys = DatabaseHelper(context).getPublicKeys()
+    }
+
+    LaunchedEffect(Unit) { refresh() }
 
     val importLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocument()
@@ -73,6 +90,8 @@ fun ContactListScreen(onAddContact: () -> Unit) {
                     val imported = KeyImportService(context).importArmoredKey(armored)
                     if (imported == 0) {
                         Toast.makeText(context, context.getString(R.string.msg_no_keys_found), Toast.LENGTH_LONG).show()
+                    } else {
+                        refresh()
                     }
                 } catch (e: Exception) {
                     val msg = when (e.message) {
@@ -87,18 +106,124 @@ fun ContactListScreen(onAddContact: () -> Unit) {
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        if (contacts.isEmpty()) {
-            Text(stringResource(R.string.msg_no_contacts), modifier = Modifier.align(Alignment.Center))
+        if (keys.isEmpty()) {
+            Text(stringResource(R.string.msg_no_public_keys), modifier = Modifier.align(Alignment.Center))
         } else {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(contacts) { contact ->
-                    ListItem(
-                        headlineContent = { Text(contact.name) },
-                        supportingContent = { Text(contact.publicKey) }
-                    )
-                    Divider()
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(bottom = 100.dp)) {
+                items(keys) { key ->
+                    Card(
+                        onClick = { keyToView = key },
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .fillMaxWidth()
+                            .shadow(2.dp, RoundedCornerShape(8.dp)),
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (isDarkTheme) Color(0xFF363636) else Color.White,
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+                        border = if (isDarkTheme) BorderStroke(0.dp, Color.Black) else BorderStroke(0.5.dp, Color(0xFFDDDDDD))
+                    ) {
+                        Row(modifier = Modifier.fillMaxWidth().padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(text = key.comment ?: key.userId ?: "?")
+                                Text(text = "Fingerprint:", fontSize = 11.sp, color = if (isDarkTheme) Color(0xFFEEAAAA) else Color(0xFFAA5555))
+                                Text(text = key.fingerprint, fontSize = 10.sp)
+                                key.createdAt?.let {
+                                    val date = Date(it * 1000)
+                                    val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                                    Text("Generated: " + fmt.format(date), fontSize = 12.sp)
+                                }
+                            }
+                            IconButton(onClick = { keyToDelete = key }) {
+                                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.cd_delete_key))
+                            }
+                        }
+                    }
                 }
             }
+        }
+
+        keyToDelete?.let { pending ->
+            AlertDialog(
+                onDismissRequest = { keyToDelete = null },
+                confirmButton = {
+                    TextButton(onClick = {
+                        DatabaseHelper(context).deleteKey(pending.fingerprint)
+                        keyToDelete = null
+                        refresh()
+                    }) { Text(stringResource(R.string.action_delete)) }
+                },
+                dismissButton = {
+                    TextButton(onClick = { keyToDelete = null }) {
+                        Text(stringResource(R.string.action_close))
+                    }
+                },
+                title = { Text(stringResource(R.string.cd_delete_key)) },
+                text = { Text(stringResource(R.string.confirm_delete_key)) }
+            )
+        }
+
+        keyToView?.let { viewKey ->
+            AlertDialog(
+                onDismissRequest = { keyToView = null },
+                confirmButton = {
+                    TextButton(onClick = { keyToView = null }) {
+                        Text(stringResource(R.string.action_close))
+                    }
+                },
+                title = { Text(stringResource(R.string.title_public_key)) },
+                text = {
+                    val clipboardManager = LocalClipboardManager.current
+                    val publicKey = remember(viewKey) {
+                        PgpKeyUtils.extractPublicKey(viewKey.armoredKey) ?: ""
+                    }
+
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(200.dp)
+                                .padding(12.dp)
+                                .verticalScroll(rememberScrollState())
+                        ) {
+                            Text(
+                                text = publicKey,
+                                fontSize = 12.sp,
+                                color = if (isDarkTheme) Color.White else Color.Black
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Button(
+                            onClick = {
+                                clipboardManager.setText(AnnotatedString(publicKey))
+                            },
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            shape = RoundedCornerShape(3.dp)
+                        ) {
+                            Icon(Icons.Default.ContentCopy, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.action_copy_public_key))
+                        }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Button(
+                            onClick = {
+                                clipboardManager.setText(AnnotatedString(viewKey.armoredKey))
+                            },
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            shape = RoundedCornerShape(3.dp)
+                        ) {
+                            Icon(Icons.Default.ContentCopy, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.action_copy_private_key))
+                        }
+                    }
+                }
+            )
         }
 
         FloatingActionButton(
@@ -119,11 +244,4 @@ fun ContactListScreen(onAddContact: () -> Unit) {
             Icon(Icons.Default.FileOpen, contentDescription = stringResource(R.string.cd_import_key))
         }
     }
-}
-
-// Simple data structures kept here for now
-data class Contact(val name: String, val publicKey: String)
-
-object ContactRepository {
-    val contacts = mutableStateListOf<Contact>()
 }

--- a/app/src/main/java/engineer/warfare/pgpandy/DatabaseHelper.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/DatabaseHelper.kt
@@ -142,6 +142,35 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DB_NAME, null
     }
 
     /**
+     * Returns all public keys stored in the database.
+     */
+    fun getPublicKeys(): List<PgpKeyInfo> {
+        val keys = mutableListOf<PgpKeyInfo>()
+        readableDatabase.rawQuery(
+            "SELECT user_id, fingerprint, key_id, is_private, armored_key, algorithm, bit_length, comment, created_at, expires_at FROM pgp_keys WHERE is_private = 0",
+            null
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                keys.add(
+                    PgpKeyInfo(
+                        userId = cursor.getString(0),
+                        fingerprint = cursor.getString(1),
+                        keyId = cursor.getString(2),
+                        isPrivate = cursor.getInt(3) == 1,
+                        armoredKey = cursor.getString(4),
+                        algorithm = cursor.getString(5),
+                        bitLength = if (cursor.isNull(6)) null else cursor.getInt(6),
+                        comment = cursor.getString(7),
+                        createdAt = if (cursor.isNull(8)) null else cursor.getLong(8),
+                        expiresAt = if (cursor.isNull(9)) null else cursor.getLong(9)
+                    )
+                )
+            }
+        }
+        return keys
+    }
+
+    /**
      * Deletes a key by its fingerprint.
      */
     fun deleteKey(fingerprint: String) {

--- a/app/src/main/java/engineer/warfare/pgpandy/MainActivity.kt
+++ b/app/src/main/java/engineer/warfare/pgpandy/MainActivity.kt
@@ -228,7 +228,7 @@ fun PGPAndyApp(initialLanguageTag: String) {
                     when (screen) {
                         Screen.Inbox -> InboxScreen()
                         Screen.Message -> MessageForm()
-                        Screen.ContactList -> ContactListScreen { screen = Screen.AddContact }
+                        Screen.ContactList -> ContactListScreen(isDarkTheme = darkTheme) { screen = Screen.AddContact }
                         Screen.KeyList -> KeyListScreen(isDarkTheme = darkTheme)
                         Screen.AddContact -> ContactForm { screen = Screen.ContactList }
                         Screen.Help -> HelpScreen()

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Importar</string>
     <string name="cd_import_key">Importar clave</string>
     <string name="msg_no_private_keys">Aún no hay claves privadas</string>
+    <string name="msg_no_public_keys">Aún no hay claves públicas</string>
     <string name="msg_invalid_key_file">Seleccione un archivo .asc válido</string>
     <string name="cd_delete_key">Eliminar clave</string>
     <string name="confirm_delete_key">¿Eliminar esta clave?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Importer</string>
     <string name="cd_import_key">Importer la clé</string>
     <string name="msg_no_private_keys">Aucune clé privée</string>
+    <string name="msg_no_public_keys">Aucune clé publique</string>
     <string name="msg_invalid_key_file">Veuillez sélectionner un fichier .asc valide</string>
     <string name="cd_delete_key">Supprimer la clé</string>
     <string name="confirm_delete_key">Supprimer cette clé ?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Импорт</string>
     <string name="cd_import_key">Импортировать ключ</string>
     <string name="msg_no_private_keys">Пока нет приватных ключей</string>
+    <string name="msg_no_public_keys">Пока нет публичных ключей</string>
     <string name="msg_invalid_key_file">Пожалуйста, выберите корректный файл .asc</string>
     <string name="cd_delete_key">Удалить ключ</string>
     <string name="confirm_delete_key">Удалить этот ключ?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_import">Import</string>
     <string name="cd_import_key">Import Key</string>
     <string name="msg_no_private_keys">No private keys yet.</string>
+    <string name="msg_no_public_keys">No public keys yet.</string>
     <string name="msg_invalid_key_file">Please select a valid .asc file</string>
     <string name="cd_delete_key">Delete key</string>
     <string name="confirm_delete_key">Delete this key?</string>


### PR DESCRIPTION
## Summary
- add database helper for public key retrieval
- show stored public keys in contact screen
- pass theme to contact screen
- localize new `msg_no_public_keys` string

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_685c893eff68832d85e18bdf62b73e21